### PR TITLE
Typing test duration

### DIFF
--- a/src/ConsolekeyType.Infrastructure/Migrations/202305290837-CreateTypingTests.SQL
+++ b/src/ConsolekeyType.Infrastructure/Migrations/202305290837-CreateTypingTests.SQL
@@ -5,6 +5,6 @@ create table typing_tests
     language_id int, --maybe store language as plain in table?
     start_time  datetime,
     end_time    datetime,
-    duration_ms int, --remove this because we can calculate it?
+    duration    time, --remove this because we can calculate it?
     FOREIGN KEY (language_id) REFERENCES language (id)
 );

--- a/src/ConsolekeyType.Infrastructure/Repositories/TypingTestRepository.cs
+++ b/src/ConsolekeyType.Infrastructure/Repositories/TypingTestRepository.cs
@@ -19,15 +19,15 @@ public class TypingTestRepository : ITypingTestRepository
         using var command = new SQLiteCommand(connection);
         command.CommandText = @"
 insert into typing_tests(
-                        text, language_id, start_time, end_time, duration_ms
+                        text, language_id, start_time, end_time, duration
 )
-values (@text, @language_id, @start_time, @end_time, @duration_ms)
+values (@text, @language_id, @start_time, @end_time, @duration)
 ";
         command.Parameters.AddWithValue("@language_id", typingTest.Text.Language.Id);
         command.Parameters.AddWithValue("@text", typingTest.Text.ToString());
         command.Parameters.AddWithValue("@start_time", typingTest.StartTime);
         command.Parameters.AddWithValue("@end_time", typingTest.EndTime);
-        command.Parameters.AddWithValue("@duration_ms", typingTest.Duration.Value.Milliseconds);
+        command.Parameters.AddWithValue("@duration", typingTest.Duration.Value);
 
         connection.Open();
         var inserted = command.ExecuteNonQuery();

--- a/tests/ConsolekeyType.IntegrationTests/TypingTestTests.cs
+++ b/tests/ConsolekeyType.IntegrationTests/TypingTestTests.cs
@@ -12,7 +12,7 @@ public class TypingTestTests
         "data source = test.db;version = 3;failifmissing = false";
 
     private readonly DateTime _startTime = new(2020, 1, 1, 10, 0, 0, 50);
-    private readonly DateTime _endTime = new(2020, 1, 1, 10, 0, 0, 440);
+    private readonly DateTime _endTime = new(2020, 1, 1, 10, 0, 2, 440);
 
     [SetUp]
     public void SetUp()

--- a/tests/ConsolekeyType.UnitTests/TypingTestTests.cs
+++ b/tests/ConsolekeyType.UnitTests/TypingTestTests.cs
@@ -5,8 +5,8 @@ public class TypingTestTests
 {
     private const string _defaultStr = "ponchi the dog";
     private readonly DateTime _startTime = new DateTime(2020, 1, 1, 10, 0, 0, 50);
-    private readonly DateTime _endTime = new DateTime(2020, 1, 1, 10, 0, 0, 440);
-    private readonly TimeSpan _duration = TimeSpan.FromMilliseconds(390);
+    private readonly DateTime _endTime = new DateTime(2020, 1, 1, 10, 0, 2, 440);
+    private readonly TimeSpan _duration = TimeSpan.FromMilliseconds(2390);
 
     [Test]
     public void Create()


### PR DESCRIPTION
Closes #16.

The actual bug was in `Save()` method in `TypingTestRepository`, where I referred to milliseconds property of `TimeSpan`, excluding seconds, etc.