### PR TITLE
Add saving cpm and wpm in the database

### DIFF
--- a/src/ConsolekeyType.Domain/SeedWork/IRepositoryT.cs
+++ b/src/ConsolekeyType.Domain/SeedWork/IRepositoryT.cs
@@ -1,6 +1,0 @@
-namespace ConsolekeyType.Domain.SeedWork;
-
-public interface IRepository<T> where T : IAggregateRoot
-{
-    private protected string _connectionString { get; }
-}

--- a/src/ConsolekeyType.Infrastructure/Migrations/202305290837-CreateTypingTests.SQL
+++ b/src/ConsolekeyType.Infrastructure/Migrations/202305290837-CreateTypingTests.SQL
@@ -2,9 +2,11 @@ create table typing_tests
 (
     id          integer primary key autoincrement,
     text        text,
-    language_id int, --maybe store language as plain in table?
+    language_id int,
     start_time  datetime,
     end_time    datetime,
     duration    time, --remove this because we can calculate it?
+    cpm         real,
+    wpm         real,
     FOREIGN KEY (language_id) REFERENCES language (id)
 );

--- a/tests/ConsolekeyType.IntegrationTests/TypingTestTests.cs
+++ b/tests/ConsolekeyType.IntegrationTests/TypingTestTests.cs
@@ -55,6 +55,8 @@ public class TypingTestTests
         retrievedTypingTest.StartTime.Should().Be(savedTypingTest.StartTime);
         retrievedTypingTest.EndTime.Should().Be(savedTypingTest.EndTime);
         retrievedTypingTest.Duration.Value.Should().Be(savedTypingTest.Duration.Value);
+        retrievedTypingTest.CPM.Value.Should().Be(savedTypingTest.CPM.Value);
+        retrievedTypingTest.WPM.Value.Should().Be(savedTypingTest.WPM.Value);
     }
 
     private Result<TypingTest> SaveDefaultTypingTestToDatabase()
@@ -62,6 +64,22 @@ public class TypingTestTests
         var text = Text.Create("ponchi is a fluffy corgi pembroke", Language.English);
         var typingTest = TypingTest.Create(text.Value).Value;
         typingTest.Start(_startTime);
+
+        typingTest.EnterChar('p');
+        typingTest.EnterChar('o');
+        typingTest.EnterChar('n');
+        typingTest.EnterChar('c');
+        typingTest.EnterChar('h');
+        typingTest.EnterChar('i');
+        typingTest.EnterChar(' ');
+        typingTest.EnterChar('t');
+        typingTest.EnterChar('h');
+        typingTest.EnterChar('e');
+        typingTest.EnterChar(' ');
+        typingTest.EnterChar('d');
+        typingTest.EnterChar('o');
+        typingTest.EnterChar('g');
+
         typingTest.End(_endTime);
 
         var repo = new TypingTestRepository(GetOptions());


### PR DESCRIPTION
Closes #24.

WPM and CPM are no more get-only props because private setters are used in the infrastructure layer by reflection